### PR TITLE
Escape table names using a backtick.

### DIFF
--- a/mysql2phinx.php
+++ b/mysql2phinx.php
@@ -71,8 +71,8 @@ function getTableMigration($table, $mysqli, $indent)
     $ind = getIndentation($indent);
 
     $output = array();
-    $output[] = $ind . '// Migration for table ' . $table;
-    $output[] = $ind . '$table = $this->table(\'' . $table . '\');';
+    $output[] = $ind . '// Migration for table `' . $table . '`';
+    $output[] = $ind . '$table = $this->table(\'`' . $table . '`' . '\');';
     $output[] = $ind . '$table';
 
     $columns = getColumns($table, $mysqli);
@@ -202,7 +202,7 @@ function getTables($mysqli)
  */
 function getColumns($table, $mysqli)
 {
-    $res = $mysqli->query('SHOW COLUMNS FROM ' . $table);
+    $res = $mysqli->query('SHOW COLUMNS FROM `' . $table . '`');
     $columns = $res->fetch_all(MYSQLI_ASSOC);
     mysqli_free_result($res);
     return $columns;
@@ -216,7 +216,7 @@ function getColumns($table, $mysqli)
  */
 function getIndexes($table, $mysqli)
 {
-    $res = $mysqli->query('SHOW INDEXES FROM ' . $table);
+    $res = $mysqli->query('SHOW INDEXES FROM `' . $table . '`');
     $indexes = $res->fetch_all(MYSQLI_ASSOC);
     mysqli_free_result($res);
     return $indexes;


### PR DESCRIPTION
Allows for reserved-keyword table names.

To see the issue this fixes, create a table named "order" and then attempt to run the utility.

You will get the error:

	PHP Fatal error:  Call to a member function fetch_all() on a non-object in www\mysql2phinx.php on line 256
	PHP Stack trace:
	PHP   1. {main}() www\mysql2phinx.php:0
	PHP   2. createMigration() www\mysql2phinx.php:310
	PHP   3. getTableMigration() www\mysql2phinx.php:33
	PHP   4. getColumns() www\mysql2phinx.php:58

	Fatal error: Call to a member function fetch_all() on a non-object in www\mysql2phinx.php on line 256

	Call Stack:
		0.0005     166000   1. {main}() www\mysql2phinx.php:0
		0.0085     173688   2. createMigration() www\mysql2phinx.php:310
		6.9745     217888   3. getTableMigration() www\mysql2phinx.php:33
		6.9745     218424   4. getColumns() www\mysql2phinx.php:58

With this commit, the given error is fixed (table names are now always interpreted as table names)